### PR TITLE
Add getChainId method to RIFWallet

### DIFF
--- a/src/RIFWallet.ts
+++ b/src/RIFWallet.ts
@@ -54,6 +54,7 @@ export class RIFWallet extends Signer {
   }
 
   getAddress = (): Promise<string> => Promise.resolve(this.smartWallet.smartWalletAddress)
+  getChainId = (): Promise<number> => this.wallet.getChainId()
 
   signMessage = (message: string | Bytes): Promise<string> => this.smartWallet.wallet.signMessage(message)
   signTransaction = (transaction: TransactionRequest): Promise<string> => this.smartWallet.wallet.signTransaction(transaction)


### PR DESCRIPTION
Adds the getChainId method that is required by tokenMetadata: https://github.com/rsksmart/swallet/blob/main/src/lib/token/tokenMetadata.ts#L56