### PR TITLE
[Security] bump abi-enhancer without axios as dependency

### DIFF
--- a/packages/abiEnhancer/package-lock.json
+++ b/packages/abiEnhancer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rif-wallet-abi-enhancer",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rif-wallet-abi-enhancer",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "ISC",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",

--- a/packages/abiEnhancer/package.json
+++ b/packages/abiEnhancer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-wallet-abi-enhancer",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "ABI Enhancer Library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
It's necessary to bump abi-enhancer because the version [1.0.9](https://registry.npmjs.org/@rsksmart/rif-wallet-abi-enhancer/-/rif-wallet-abi-enhancer-1.0.9.tgz) is still showing axios as dependency causing conflicts.

This should fix https://github.com/rsksmart/rif-wallet-libs/security/dependabot/42